### PR TITLE
Update AWS Provider by 4.9.0

### DIFF
--- a/settings.tf
+++ b/settings.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.8.0"
+      version = ">=4.9.0"
     }
   }
 }


### PR DESCRIPTION
I'd like to suggest a couple of changes to the version management.

Replace "~>" (Pessimistic constraint operator) to ">=" (Greater-than).
According to [the docs](https://developer.hashicorp.com/terraform/language/providers/requirements#best-practices-for-provider-versions), this is a recommended way for a module that is used across many configurations.

Up the minimum version of AWS provider to 4.0.9 due to the recommendation from [the docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade).





